### PR TITLE
Require players to start a round manually

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
       <span class="pill">Net: <b id="netOut">0 gp 0 sp</b></span>
     </div>
 
-    <div class="log" id="log">Welcome to the pit. Place your wager and choose your target.</div>
+    <div class="log" id="log">Welcome to the pit. Press "New Round" to begin.</div>
   </section>
 </div>
 
@@ -99,7 +99,7 @@ const fmtSp = (spTotal) => {
 /* ===== State ===== */
 let spentSp = 0;
 let wonSp   = 0;
-let roundOpen = true;
+let roundOpen = false;
 
 const imgLeft   = document.getElementById('imgLeft');
 const imgRight  = document.getElementById('imgRight');
@@ -280,8 +280,9 @@ function seedStartFaces(){
 }
 seedStartFaces();
 updateLedger();
-// Start with hammer cursor active on first load as well
-document.body.classList.add('hammer-cursor');
+setClickable(false);
+document.body.classList.remove('hammer-cursor');
+logEl.textContent = 'Press "New Round" to start the game.';
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- start the experience with the round closed so boxes cannot be clicked until the player opens a new round
- update the log copy to instruct players to press "New Round" before betting

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ef1d86544c832ca0c3726fe0a6fc85